### PR TITLE
Update test scripts for windows

### DIFF
--- a/start-server.ps1
+++ b/start-server.ps1
@@ -1,0 +1,1 @@
+docker run -d -p 5000:80 --env NUGET_API_KEY=1234 --name nuget-server sunside/simple-nuget-server

--- a/test-publish.ps1
+++ b/test-publish.ps1
@@ -1,0 +1,20 @@
+
+cd src/NugetPushIssueRepro/
+
+rimraf ./build
+rimraf ./bin
+rimraf ./obj
+dotnet restore
+dotnet build --no-incremental -c Release
+
+dotnet ./bin/Release/netcoreapp1.1/NugetPushIssueRepro.dll
+
+$rnd = Get-Random
+$suffix = "publishtest$rnd"
+
+# add a random number to the prerelease string so we don't have to worry about the version already existing and killing the server every time
+dotnet pack --no-build -o build -c Release --version-suffix $suffix
+
+dotnet nuget push ./build/NugetPushIssueRepro.3.0.0-$suffix.nupkg --api-key 1234 --source http://localhost:5000/api/v2/package
+
+cd ../..

--- a/test-publish.sh
+++ b/test-publish.sh
@@ -3,9 +3,9 @@
 set -ex
 
 cd src/NugetPushIssueRepro/
-rimraf ./build
-rimraf ./bin
-rimraf ./obj
+rm -rf ./build
+rm -rf ./bin
+rm -rf ./obj
 dotnet restore
 dotnet build --no-incremental -c Release
 
@@ -16,3 +16,4 @@ dotnet pack --no-build -o build -c Release --version-suffix publishtest`echo $RA
 
 dotnet nuget push ./build/*.nupkg --api-key 1234 --source http://localhost:5000/api/v2/package
 
+cd ../../


### PR DESCRIPTION
This PR adds powershell versions of the `test-publish` and `start-server` scripts. It also updates the `test-publish.sh` script to use `rm -rf` instead of the `rimraf` node module.